### PR TITLE
Kickstart PouchDB in Vue

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "vite": "^5.1.5",
     "vite-plugin-electron": "^0.28.4",
     "vite-plugin-electron-renderer": "^0.14.5",
+    "vite-plugin-node-polyfills": "^0.22.0",
     "vue": "^3.4.21",
     "vue-tsc": "^2.0.6"
   },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
+    "@types/pouchdb-browser": "^6.1.5",
     "@vitejs/plugin-vue": "^5.0.4",
     "electron": "^29.1.1",
     "electron-builder": "^24.13.3",
@@ -36,7 +37,6 @@
     "vue-tsc": "^2.0.6"
   },
   "dependencies": {
-    "@types/pouchdb": "^6.4.2",
-    "pouchdb": "^9.0.0"
+    "pouchdb-browser": "^9.0.0"
   }
 }

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-import PouchDB from 'pouchdb'
+import PouchDB from 'pouchdb-browser'
 defineProps<{ msg: string }>()
 // There will be problems here.
 const db = new PouchDB('test')

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import electron from 'vite-plugin-electron/simple'
 import pkg from './package.json'
+import { nodePolyfills } from 'vite-plugin-node-polyfills'
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command }) => {
@@ -14,6 +15,7 @@ export default defineConfig(({ command }) => {
 
   return {
     plugins: [
+      nodePolyfills(),
       vue(),
       electron({
         main: {


### PR DESCRIPTION
In the end, it was simple to fix.

1st commit: make use of package "pouchdb-browser" (specialized build for browsers).
2nd: brings "vite-plugin-node-polyfills" into your build pipeline.